### PR TITLE
splice macros undeclared

### DIFF
--- a/c_src/splicer.c
+++ b/c_src/splicer.c
@@ -15,7 +15,7 @@
  */
 
 // for access to nonstandard GNU/Linux functions and macros
-#define __USE_GNU
+#define _GNU_SOURCE
 
 #include "erl_nif.h"
 #include <fcntl.h>

--- a/c_src/splicer.c
+++ b/c_src/splicer.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// for access to nonstandard GNU/Linux functions and macros
+#define __USE_GNU
+
 #include "erl_nif.h"
 #include <fcntl.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
splicer fails to cross-compile under Buildroot when included as a dependency in a `rebar.config`.

```
output/build/myapp/_build/default/lib/splicer/c_src/splicer.c:92:91: error: ‘SPLICE_F_MORE’ undeclared (first use in this function); did you mean ‘SPLICE_F_MOVE’?
                     res = splice(mypipe->pipefd[0], NULL, wfd, NULL, res, SPLICE_F_MOVE | SPLICE_F_MORE);
                                                                                           ^~~~~~~~~~~~~
                                                                                           SPLICE_F_MOVE
```

This old post on the Buildroot mailing list explains why.

http://lists.busybox.net/pipermail/buildroot/2011-March/041724.html
